### PR TITLE
Support GitHub Enterprise

### DIFF
--- a/spec/ghe_spec.rb
+++ b/spec/ghe_spec.rb
@@ -42,13 +42,13 @@ describe '...' do
     it "should access to api.github.com when $GHE_URL wasn't set" do
       ENV.delete 'GHE_URL'
       Jist.login!
-      assert_requested(:post, /api.github.com/)
+      assert_requested(:post, /api.github.com\/authorizations/)
     end
 
     it "should access to #{MOCK_GHE_HOST} when $GHE_URL was set" do
       ENV['GHE_URL'] = MOCK_GHE_URL
       Jist.login!
-      assert_requested(:post, /#{MOCK_GHE_HOST}/)
+      assert_requested(:post, /#{MOCK_GHE_HOST}\/api\/v3\/authorizations/)
     end
   end
 
@@ -56,13 +56,13 @@ describe '...' do
     it "should access to api.github.com when $GHE_URL wasn't set" do
       ENV.delete 'GHE_URL'
       Jist.gist "test gist"
-      assert_requested(:post, /api.github.com/)
+      assert_requested(:post, /api.github.com\/gists/)
     end
 
     it "should access to #{MOCK_GHE_HOST} when $GHE_URL was set" do
       ENV['GHE_URL'] = MOCK_GHE_URL
       Jist.gist "test gist"
-      assert_requested(:post, /#{MOCK_GHE_HOST}/)
+      assert_requested(:post, /#{MOCK_GHE_HOST}\/api\/v3\/gists/)
     end
   end
 end

--- a/spec/ghe_spec.rb
+++ b/spec/ghe_spec.rb
@@ -1,0 +1,68 @@
+describe '...' do
+
+  MOCK_GHE_HOST = 'ghe.example.com'
+  MOCK_USER = 'foo'
+  MOCK_PASSWORD = 'bar'
+  MOCK_AUTHZ_GHE_URL = "http://#{MOCK_USER}:#{MOCK_PASSWORD}@#{MOCK_GHE_HOST}/"
+  MOCK_GHE_URL = "http://#{MOCK_GHE_HOST}/"
+
+  before do
+    @saved_env = ENV['GHE_URL']
+
+    # stub requests for /gists
+    stub_request(:post, /^#{MOCK_GHE_URL}api\/v3\/gists/).to_return(:body => %[{"html_url": "#{MOCK_GHE_URL}"}])
+    stub_request(:post, /^https:\/\/api.github.com\/gists/).to_return(:body => '{"html_url": "http://github.com/"}')
+
+    # stub requests for /authorizations
+    stub_request(:post, /^#{MOCK_AUTHZ_GHE_URL}api\/v3\/authorizations/).
+      to_return(:status => 201, :body => '{"token": "asdf"}')
+    stub_request(:post, /^https:\/\/#{MOCK_USER}:#{MOCK_PASSWORD}@api.github.com\/authorizations/).
+      to_return(:status => 201, :body => '{"token": "asdf"}')
+  end
+
+  after do
+    ENV['GHE_URL'] = @saved_env
+  end
+
+  describe :login! do
+    before do
+      @saved_stdin = $stdin
+
+      # stdin emulation
+      $stdin = StringIO.new "#{MOCK_USER}\n#{MOCK_PASSWORD}\n"
+
+      # intercept for updating ~/.jist
+      File.stub(:open)
+    end
+
+    after do
+      $stdin = @saved_stdin
+    end
+
+    it "should access to api.github.com when $GHE_URL wasn't set" do
+      ENV.delete 'GHE_URL'
+      Jist.login!
+      assert_requested(:post, /api.github.com/)
+    end
+
+    it "should access to #{MOCK_GHE_HOST} when $GHE_URL was set" do
+      ENV['GHE_URL'] = MOCK_GHE_URL
+      Jist.login!
+      assert_requested(:post, /#{MOCK_GHE_HOST}/)
+    end
+  end
+
+  describe :gist do
+    it "should access to api.github.com when $GHE_URL wasn't set" do
+      ENV.delete 'GHE_URL'
+      Jist.gist "test gist"
+      assert_requested(:post, /api.github.com/)
+    end
+
+    it "should access to #{MOCK_GHE_HOST} when $GHE_URL was set" do
+      ENV['GHE_URL'] = MOCK_GHE_URL
+      Jist.gist "test gist"
+      assert_requested(:post, /#{MOCK_GHE_HOST}/)
+    end
+  end
+end


### PR DESCRIPTION
if you use jist with GitHub Enterprise, you shuold run with `--login` at first.
Because GHE needs OAuth token.
## Usage

In terminal:

``` sh
$ export GHE_URL=<your_ghe_url> 
$ jist --login
$ jist a.rb
```

If you want to stop using GHE, run `$ unset GHE_URL`.
### TODO
- [x] tests
- [x] var name review
