### PR TITLE
Store the token config file in $XDG_CONFIG_HOME

### DIFF
--- a/lib/jist.rb
+++ b/lib/jist.rb
@@ -55,7 +55,7 @@ module Jist
   # @option options [String] :description  the description
   # @option options [Boolean] :public  (false) is this gist public
   # @option options [Boolean] :anonymous  (false) is this gist anonymous
-  # @option options [String] :access_token  (`File.read("~/.jist")`) The OAuth2 access token.
+  # @option options [String] :access_token  ($XDG_CONFIG_HOME/jist) The OAuth2 access token.
   # @option options [String] :update  the URL or id of a gist to update
   # @option options [Boolean] :copy  (false) Copy resulting URL to clipboard, if successful.
   # @option options [Boolean] :open  (false) Open the resulting URL in a browser.
@@ -134,7 +134,7 @@ module Jist
   # Log the user into jist.
   #
   # This method asks the user for a username and password, and tries to obtain
-  # and OAuth2 access token, which is then stored in ~/.jist
+  # and OAuth2 access token, which is then stored in $XDG_CONFIG_HOME/jist
   #
   # @raise [Jist::Error]  if something went wrong
   # @see http://developer.github.com/v3/oauth/
@@ -337,10 +337,12 @@ Could not find copy command, tried:
   end
 
   def auth_token_file
+    config_file = ENV.fetch('XDG_CONFIG_HOME', '~/.config') + '/jist'
+
     if ENV.key?(URL_ENV_NAME)
-      File.expand_path "~/.jist.#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}"
+      File.expand_path "#{config_file}.#{ENV[URL_ENV_NAME].gsub(/[^a-z.]/, '')}"
     else
-      File.expand_path "~/.jist"
+      File.expand_path config_file
     end
   end
 end

--- a/spec/ghe_spec.rb
+++ b/spec/ghe_spec.rb
@@ -35,7 +35,7 @@ describe '...' do
       # stdin emulation
       $stdin = StringIO.new "#{MOCK_USER}\n#{MOCK_PASSWORD}\n"
 
-      # intercept for updating ~/.jist
+      # intercept for updating $XDG_CONFIG_HOME/jist
       File.stub(:open)
     end
 


### PR DESCRIPTION
This moves the `~/.jist` file into the `$XDG_CONFIG_HOME` directory as to follow the [Freedesktop.org XDG base directory specifications](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).

This will read the token from the `$XDG_CONFIG_HOME/jist` file, or if the `$XDG_CONFIG_HOME` environment variable isn't set, it will default to `~/.config/jist`.

I haven't really considered the implications for OSX or Windows for this patch. I did [a little googling](http://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x) on what the equivilents are on OSX for the XDG folders, but didn't come to any solid conclusions. I didn't do any looking into if it makes sense for it to be stored in `~/.config/` on windows (TBH, I really have no idea what that would even expand to on windows).

Also, users with a `.jist` file currently in their home directory will have to move it to `~/.config/jist`.
